### PR TITLE
Adds trigger build command to Jenkins plugin, refs #10

### DIFF
--- a/plugins/jenkins.rb
+++ b/plugins/jenkins.rb
@@ -92,6 +92,16 @@ module Jenkins
 
       'current status unknown'
     end
+
+    def build!
+      res = get_http "#{url}/build"
+
+      if res.is_a? ::Net::HTTPFound
+        "Build started"
+      else
+        "Could not start build (#{res.code})"
+      end
+    end
   end
 
   class Build < Path
@@ -174,3 +184,10 @@ Basil.respond_to(/^who broke (.+?)\??$/) {
   end
 
 }.description = 'tells you the likely culprits for a broken build'
+
+Basil.respond_to(/^build (\w+)/) {
+
+  says Jenkins::Job.new(@match_data[1]).build!
+
+}.description = 'triggers a build for the specified job'
+


### PR DESCRIPTION
Hi,

I added a simple `build <job>` command for Jenkins to trigger a build on that specific job.

However, I don't think there is a proper way to check if the build has really been started, so I'm only checking the response code.

Zaki
